### PR TITLE
VP-2606: Exception is throwing on cart saving attempt

### DIFF
--- a/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartService.cs
+++ b/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartService.cs
@@ -11,7 +11,6 @@ using VirtoCommerce.CartModule.Data.Model;
 using VirtoCommerce.CartModule.Data.Repositories;
 using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Common;
-using VirtoCommerce.Platform.Core.DynamicProperties;
 using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.Platform.Data.Infrastructure;
 
@@ -88,13 +87,14 @@ namespace VirtoCommerce.CartModule.Data.Services
                     var originalEntity = dataExistCarts.FirstOrDefault(x => x.Id == cart.Id);
                     var modifiedEntity = AbstractTypeFactory<ShoppingCartEntity>.TryCreateInstance()
                                                                                 .FromModel(cart, pkMap);
-                    /// This extension is allow to get around breaking changes is introduced in EF Core 3.0 that leads to throw
-                    /// Database operation expected to affect 1 row(s) but actually affected 0 row(s) exception when trying to add the new children entities with manually set keys
-                    /// https://docs.microsoft.com/en-us/ef/core/what-is-new/ef-core-3.0/breaking-changes#detectchanges-honors-store-generated-key-values
-                    repository.TrackModifiedAsAddedForNewChildEntities(originalEntity);
 
                     if (originalEntity != null)
                     {
+                        // This extension is allow to get around breaking changes is introduced in EF Core 3.0 that leads to throw
+                        // Database operation expected to affect 1 row(s) but actually affected 0 row(s) exception when trying to add the new children entities with manually set keys
+                        // https://docs.microsoft.com/en-us/ef/core/what-is-new/ef-core-3.0/breaking-changes#detectchanges-honors-store-generated-key-values
+                        repository.TrackModifiedAsAddedForNewChildEntities(originalEntity);
+
                         changedEntries.Add(new GenericChangedEntry<ShoppingCart>(cart, originalEntity.ToModel(AbstractTypeFactory<ShoppingCart>.TryCreateInstance()), EntryState.Modified));
                         modifiedEntity.Patch(originalEntity);
                     }


### PR DESCRIPTION
### Problem
Can't create a cart

### Solution
Cart should be created

### Proposed of changes
Fix it

### Additional context (optional)
![cart_creating_fix](https://user-images.githubusercontent.com/15198683/83011711-a2d9d480-a01a-11ea-8ebf-4af5607b125c.gif)

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
