### PR TITLE
VP-4410: Add search criteria to filter by date

### DIFF
--- a/src/VirtoCommerce.CartModule.Core/Model/Search/ShoppingCartSearchCriteria.cs
+++ b/src/VirtoCommerce.CartModule.Core/Model/Search/ShoppingCartSearchCriteria.cs
@@ -1,3 +1,4 @@
+using System;
 using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.CartModule.Core.Model.Search
@@ -12,5 +13,11 @@ namespace VirtoCommerce.CartModule.Core.Model.Search
         public string Type { get; set; }
         public string[] CustomerIds { get; set; }
         public string OrganizationId { get; set; }
+
+        public DateTime? StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+
+        public DateTime? ModifiedStartDate { get; set; }
+        public DateTime? ModifiedEndDate { get; set; }
     }
 }

--- a/src/VirtoCommerce.CartModule.Core/Model/Search/ShoppingCartSearchCriteria.cs
+++ b/src/VirtoCommerce.CartModule.Core/Model/Search/ShoppingCartSearchCriteria.cs
@@ -14,8 +14,8 @@ namespace VirtoCommerce.CartModule.Core.Model.Search
         public string[] CustomerIds { get; set; }
         public string OrganizationId { get; set; }
 
-        public DateTime? StartDate { get; set; }
-        public DateTime? EndDate { get; set; }
+        public DateTime? CreatedStartDate { get; set; }
+        public DateTime? CreatedEndDate { get; set; }
 
         public DateTime? ModifiedStartDate { get; set; }
         public DateTime? ModifiedEndDate { get; set; }

--- a/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartSearchService.cs
+++ b/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartSearchService.cs
@@ -103,9 +103,29 @@ namespace VirtoCommerce.CartModule.Data.Services
                 query = query.Where(x => criteria.CustomerIds.Contains(x.CustomerId));
             }
 
+            if (criteria.StartDate != null)
+            {
+                query = query.Where(x => x.CreatedDate >= criteria.StartDate.Value);
+            }
+
+            if (criteria.EndDate != null)
+            {
+                query = query.Where(x => x.CreatedDate <= criteria.EndDate.Value);
+            }
+
+            if (criteria.ModifiedStartDate != null)
+            {
+                query = query.Where(x => x.ModifiedDate >= criteria.ModifiedStartDate.Value);
+            }
+
+            if (criteria.ModifiedEndDate != null)
+            {
+                query = query.Where(x => x.ModifiedDate <= criteria.ModifiedEndDate.Value);
+            }
+
             return query;
         }
-    
+
         protected virtual IList<SortInfo> BuildSortExpression(ShoppingCartSearchCriteria criteria)
         {
             var sortInfos = criteria.SortInfos;

--- a/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartSearchService.cs
+++ b/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartSearchService.cs
@@ -103,14 +103,14 @@ namespace VirtoCommerce.CartModule.Data.Services
                 query = query.Where(x => criteria.CustomerIds.Contains(x.CustomerId));
             }
 
-            if (criteria.StartDate != null)
+            if (criteria.CreatedStartDate != null)
             {
-                query = query.Where(x => x.CreatedDate >= criteria.StartDate.Value);
+                query = query.Where(x => x.CreatedDate >= criteria.CreatedStartDate.Value);
             }
 
-            if (criteria.EndDate != null)
+            if (criteria.CreatedEndDate != null)
             {
-                query = query.Where(x => x.CreatedDate <= criteria.EndDate.Value);
+                query = query.Where(x => x.CreatedDate <= criteria.CreatedEndDate.Value);
             }
 
             if (criteria.ModifiedStartDate != null)


### PR DESCRIPTION
### Problem
The business scenario is to find abandoned carts of registered members and send them emails to encourage purchase/checkout.  We seek to send an email 1 hour after, 1 day after and 3 days after.

### Solution
Extend Search API with StartDate, EndDate, ModifiedStartDate, ModifiedEndDate search criteria to provide ability filter cart by CreatedDate and ModifiedDate.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
