### PR TITLE
VP-6815: Add index by CustomerId, StoreId, CreateDate to Cart table

### DIFF
--- a/src/VirtoCommerce.CartModule.Data/Migrations/20210202152733_AddCartCustomerStoreDateIndex.Designer.cs
+++ b/src/VirtoCommerce.CartModule.Data/Migrations/20210202152733_AddCartCustomerStoreDateIndex.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VirtoCommerce.CartModule.Data.Repositories;
 
 namespace VirtoCommerce.CartModule.Data.Migrations
 {
     [DbContext(typeof(CartDbContext))]
-    partial class CartDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210202152733_AddCartCustomerStoreDateIndex")]
+    partial class AddCartCustomerStoreDateIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/VirtoCommerce.CartModule.Data/Migrations/20210202152733_AddCartCustomerStoreDateIndex.cs
+++ b/src/VirtoCommerce.CartModule.Data/Migrations/20210202152733_AddCartCustomerStoreDateIndex.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace VirtoCommerce.CartModule.Data.Migrations
+{
+    public partial class AddCartCustomerStoreDateIndex : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"CREATE INDEX [IX_CustomerId_StoreId_Date] ON [Cart]([CustomerId] ASC, [StoreId] ASC, [CreatedDate] DESC)");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CustomerId_StoreId_Date",
+                table: "Cart");
+        }
+    }
+}

--- a/src/VirtoCommerce.CartModule.Data/Migrations/20210202152733_AddCartCustomerStoreDateIndex.cs
+++ b/src/VirtoCommerce.CartModule.Data/Migrations/20210202152733_AddCartCustomerStoreDateIndex.cs
@@ -6,6 +6,7 @@ namespace VirtoCommerce.CartModule.Data.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // Add index thru scripting because of no way to make indexing field DESC
             migrationBuilder.Sql(@"CREATE INDEX [IX_CustomerId_StoreId_Date] ON [Cart]([CustomerId] ASC, [StoreId] ASC, [CreatedDate] DESC)");
         }
 

--- a/src/VirtoCommerce.CartModule.Data/Repositories/CartDbContext.cs
+++ b/src/VirtoCommerce.CartModule.Data/Repositories/CartDbContext.cs
@@ -23,6 +23,7 @@ namespace VirtoCommerce.CartModule.Data.Repositories
             modelBuilder.Entity<ShoppingCartEntity>().ToTable("Cart").HasKey(x => x.Id);
             modelBuilder.Entity<ShoppingCartEntity>().Property(x => x.Id).HasMaxLength(128).ValueGeneratedOnAdd();
             modelBuilder.Entity<ShoppingCartEntity>().Property(x => x.TaxPercentRate).HasColumnType("decimal(18,4)");
+            modelBuilder.Entity<ShoppingCartEntity>().HasIndex(x => new { x.CustomerId, x.StoreId, x.ModifiedDate /* (! Important !) DESC */}).HasName("IX_CustomerId_StoreId_Date");
             #endregion
 
             #region LineItem


### PR DESCRIPTION
Adding line items to the cart gives us statements like this:
``` SQL
exec sp_executesql N'SELECT [c].[Id]  FROM [Cart] AS [c]  WHERE ((((([c].[IsDeleted] = CAST(0 AS bit)) AND ([c].[Name] = @__criteria_Name_0)) AND ([c].[CustomerId] = @__criteria_CustomerId_1)) 
AND (@__criteria_StoreId_2 = [c].[StoreId])) AND ([c].[Currency] = @__criteria_Currency_3)) 
AND ([c].[Type] = @__criteria_Type_4)  
ORDER BY [c].[CreatedDate] DESC, [c].[Id]  
OFFSET @__p_5 ROWS FETCH NEXT @__p_6 ROWS ONLY',N'@__criteria_Name_0 nvarchar(64),@__criteria_CustomerId_1 nvarchar(64),@__criteria_StoreId_2 nvarchar(64),@__criteria_Currency_3 nvarchar(3),@__criteria_Type_4 nvarchar(64),@__p_5 int,@__p_6 int',@__criteria_Name_0=N'default',@__criteria_CustomerId_1=N'c068e853-bcd7-4398-955e-4967aff2c300',@__criteria_StoreId_2=N'TestStore',@__criteria_Currency_3=N'USD',@__criteria_Type_4=N'cart',@__p_5=0,@__p_6=20
```
and this:
``` SQL
exec sp_executesql N'SELECT [c].[Id]  FROM [Cart] AS [c]  WHERE (((([c].[IsDeleted] = CAST(0 AS bit)) AND ([c].[Name] = @__criteria_Name_0)) AND ([c].[CustomerId] = @__criteria_CustomerId_1)) 
AND (@__criteria_StoreId_2 = [c].[StoreId])) AND ([c].[Currency] = @__criteria_Currency_3)  
ORDER BY [c].[CreatedDate] DESC, [c].[Id]  
OFFSET @__p_4 ROWS FETCH NEXT @__p_5 ROWS ONLY',N'@__criteria_Name_0 nvarchar(64),@__criteria_CustomerId_1 nvarchar(64),@__criteria_StoreId_2 nvarchar(64),@__criteria_Currency_3 nvarchar(3),@__p_4 int,@__p_5 int',@__criteria_Name_0=N'default',@__criteria_CustomerId_1=N'c068e853-bcd7-4398-955e-4967aff2c300',@__criteria_StoreId_2=N'TestStore',@__criteria_Currency_3=N'USD',@__p_4=0,@__p_5=20

```

There were no indexes in the Cart table at all. 
I think it will be good to add:

CREATE INDEX [IX_CustomerId_StoreId_Date] ON [Cart]([CustomerId] ASC, [StoreId] ASC, [CreatedDate] DESC)

This index gives a good proportion of selection per one index row (by Customer, Store), and the sorting by CreatedDate in descendant occurs directly in the index. Look at the explain (there is really no sorting):
![image](https://user-images.githubusercontent.com/9972421/106633630-d228e400-65a0-11eb-9452-32bd0a89ea86.png)

