### PR TITLE
VP-6877: Fix issues/effects with thread hangs during forcibly cart cache release

### DIFF
--- a/src/VirtoCommerce.CartModule.Data/Caching/CartSearchCacheRegion.cs
+++ b/src/VirtoCommerce.CartModule.Data/Caching/CartSearchCacheRegion.cs
@@ -2,7 +2,7 @@ using VirtoCommerce.Platform.Core.Caching;
 
 namespace VirtoCommerce.CartModule.Data.Caching
 {
-    public class CartSearchCacheRegion : CancellableCacheRegion<CartCacheRegion>
+    public class CartSearchCacheRegion : CancellableCacheRegion<CartSearchCacheRegion>
     {
     }
 }


### PR DESCRIPTION
The bug that causes the following problem fixed:
Threads in calling for cart save/remove hangs from time to time due to the impossibility to release cache tokens. The tokens are messed up in composite tokens in a cyclic manner causing indefinite awaiting for release to each other during canceling/disposing of.

Jira: https://virtocommerce.atlassian.net/browse/VP-6877