### PR TITLE
PT-290: Skip database cart count request for most cases

### DIFF
--- a/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartSearchService.cs
+++ b/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartSearchService.cs
@@ -52,8 +52,11 @@ namespace VirtoCommerce.CartModule.Data.Services
                                          .Skip(criteria.Skip).Take(criteria.Take)
                                          .ToArrayAsync();
                         result.TotalCount = ids.Count();
-                        if (criteria.Skip != 0 || result.TotalCount == criteria.Take)
-                        {                            
+                        // This reduces a load of a relational database by skipping cart count query in case of:
+                        // * First page of the carts is reading (Skip = 0);
+                        // * Count of carts in reading result less than Take value.
+                        if (criteria.Skip > 0 || result.TotalCount == criteria.Take)
+                        {
                             forceCountQuery = true;
                         }
                         result.Results = (await _cartService.GetByIdsAsync(ids, criteria.ResponseGroup)).OrderBy(x => Array.IndexOf(ids, x.Id)).ToList();

--- a/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartSearchService.cs
+++ b/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartSearchService.cs
@@ -53,11 +53,9 @@ namespace VirtoCommerce.CartModule.Data.Services
                                          .ToArrayAsync();
 
                         result.TotalCount = ids.Count();
-#pragma warning disable S125 // Slint mis-thought it is a code
                         // This reduces a load of a relational database by skipping cart count query in case of:
-                        // * First page of the carts is reading (Skip is 0);
-                        // * Count of carts in reading result less than Take value.
-#pragma warning restore S125 // Slint mis-thought it is a code
+                        // - First page of the carts is reading (Skip is 0)
+                        // - Count of carts in reading result less than Take value.
                         if (criteria.Skip > 0 || result.TotalCount == criteria.Take)
 
                         {
@@ -82,7 +80,7 @@ namespace VirtoCommerce.CartModule.Data.Services
 
         protected virtual IQueryable<ShoppingCartEntity> BuildQuery(ICartRepository repository, ShoppingCartSearchCriteria criteria)
         {
-            var query = repository.ShoppingCarts.Where(x => x.IsDeleted == false);
+            var query = repository.ShoppingCarts.Where(x => !x.IsDeleted);
 
             if (!string.IsNullOrEmpty(criteria.Status))
             {

--- a/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartSearchService.cs
+++ b/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartSearchService.cs
@@ -53,10 +53,13 @@ namespace VirtoCommerce.CartModule.Data.Services
                                          .ToArrayAsync();
 
                         result.TotalCount = ids.Count();
+#pragma warning disable S125 // Slint mis-thought it is a code
                         // This reduces a load of a relational database by skipping cart count query in case of:
-                        // * First page of the carts is reading (Skip = 0);
+                        // * First page of the carts is reading (Skip is 0);
                         // * Count of carts in reading result less than Take value.
+#pragma warning restore S125 // Slint mis-thought it is a code
                         if (criteria.Skip > 0 || result.TotalCount == criteria.Take)
+
                         {
                             forceCountQuery = true;
                         }

--- a/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartSearchService.cs
+++ b/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartSearchService.cs
@@ -51,6 +51,7 @@ namespace VirtoCommerce.CartModule.Data.Services
                                          .Select(x => x.Id)
                                          .Skip(criteria.Skip).Take(criteria.Take)
                                          .ToArrayAsync();
+
                         result.TotalCount = ids.Count();
                         // This reduces a load of a relational database by skipping cart count query in case of:
                         // * First page of the carts is reading (Skip = 0);

--- a/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartSearchService.cs
+++ b/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartSearchService.cs
@@ -43,7 +43,7 @@ namespace VirtoCommerce.CartModule.Data.Services
                     var sortInfos = BuildSortExpression(criteria);
                     var query = BuildQuery(repository, criteria);
 
-                    var forceCountQuery = false;
+                    var needExecuteCount = criteria.Take == 0;
 
                     if (criteria.Take > 0)
                     {
@@ -59,16 +59,12 @@ namespace VirtoCommerce.CartModule.Data.Services
                         if (criteria.Skip > 0 || result.TotalCount == criteria.Take)
 
                         {
-                            forceCountQuery = true;
+                            needExecuteCount = true;
                         }
                         result.Results = (await _cartService.GetByIdsAsync(ids, criteria.ResponseGroup)).OrderBy(x => Array.IndexOf(ids, x.Id)).ToList();
                     }
-                    else
-                    {
-                        forceCountQuery = true;
-                    }
 
-                    if (forceCountQuery)
+                    if (needExecuteCount)
                     {
                         result.TotalCount = await query.CountAsync();
                     }


### PR DESCRIPTION
This reduces a load of a relational database by skipping cart count query in case of:
1. First page of the carts is reading (*Skip=0*);
2. Count of carts in reading result less than *Take* value.

Should be good to boost RDBMS performance, because it is very often case.

https://virtocommerce.atlassian.net/browse/PT-290