### PR TITLE
HDOT-4026 Fix Shipment.FulfillmentCenterName always being empty

### DIFF
--- a/src/VirtoCommerce.CartModule.Data/Model/ShipmentEntity.cs
+++ b/src/VirtoCommerce.CartModule.Data/Model/ShipmentEntity.cs
@@ -108,6 +108,7 @@ namespace VirtoCommerce.CartModule.Data.Model
             shipment.Fee = Fee;
             shipment.FeeWithTax = FeeWithTax;
             shipment.FulfillmentCenterId = FulfillmentCenterId;
+            shipment.FulfillmentCenterName = FulfillmentCenterName;
             shipment.ShipmentMethodCode = ShipmentMethodCode;
             shipment.Total = Total;
             shipment.TotalWithTax = TotalWithTax;
@@ -178,6 +179,7 @@ namespace VirtoCommerce.CartModule.Data.Model
             Fee = shipment.Fee;
             FeeWithTax = shipment.FeeWithTax;
             FulfillmentCenterId = shipment.FulfillmentCenterId;
+            FulfillmentCenterName = shipment.FulfillmentCenterName;
             ShipmentMethodCode = shipment.ShipmentMethodCode;
             Total = shipment.Total;
             TotalWithTax = shipment.TotalWithTax;


### PR DESCRIPTION
https://virtocommerce.atlassian.net/browse/HDOT-4026

Previously, cart shipments contained a `FulfillmentCenterName` property - it was added [about 1.5 years ago](https://github.com/VirtoCommerce/vc-module-cart/pull/40/files#diff-0b9ed74b8f503fd4ec33ea02ebdfebcb5b13904686d6456a1e64b239f6539341R246) and was probably meant to contain fulfillment center name. However, the code never used it in `ToModel()`/`FromModel()` methods, so this property and its corresponding column in the database were always empty. Due to this, FFC name in order shipments was always empty too (the code attempted to copy it from the cart shipment, but it was always empty there). So, this PR attempts to fix this - it simply adds the `FulfillmentCenterName` property to `ToModel()` and `FromModel()` methods.