### PR TITLE
PT-3865: Fix bug with cart deletion

### DIFF
--- a/src/VirtoCommerce.CartModule.Data/Model/ShipmentItemEntity.cs
+++ b/src/VirtoCommerce.CartModule.Data/Model/ShipmentItemEntity.cs
@@ -58,8 +58,10 @@ namespace VirtoCommerce.CartModule.Data.Model
 
             BarCode = shipmentItem.BarCode;
             Quantity = shipmentItem.Quantity;
+            LineItemId = shipmentItem.LineItemId;
 
             pkMap.AddPair(shipmentItem, this);
+            
             if (shipmentItem.LineItem != null)
             {
                 LineItemId = shipmentItem.LineItem.Id;

--- a/src/VirtoCommerce.CartModule.Data/Repositories/CartDbContext.cs
+++ b/src/VirtoCommerce.CartModule.Data/Repositories/CartDbContext.cs
@@ -50,20 +50,20 @@ namespace VirtoCommerce.CartModule.Data.Repositories
             modelBuilder.Entity<ShipmentItemEntity>().ToTable("CartShipmentItem").HasKey(x => x.Id);
             modelBuilder.Entity<ShipmentItemEntity>().Property(x => x.Id).HasMaxLength(128).ValueGeneratedOnAdd();
             modelBuilder.Entity<ShipmentItemEntity>().HasOne(x => x.LineItem).WithMany(x => x.ShipmentItems)
-                        .HasForeignKey(x => x.LineItemId).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey(x => x.LineItemId).IsRequired().OnDelete(DeleteBehavior.ClientCascade);
             modelBuilder.Entity<ShipmentItemEntity>().HasOne(x => x.Shipment).WithMany(x => x.Items)
-                        .HasForeignKey(x => x.ShipmentId).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey(x => x.ShipmentId).IsRequired().OnDelete(DeleteBehavior.ClientCascade);
             #endregion
 
             #region Address
             modelBuilder.Entity<AddressEntity>().ToTable("CartAddress").HasKey(x => x.Id);
             modelBuilder.Entity<AddressEntity>().Property(x => x.Id).HasMaxLength(128).ValueGeneratedOnAdd();
             modelBuilder.Entity<AddressEntity>().HasOne(x => x.ShoppingCart).WithMany(x => x.Addresses)
-                        .HasForeignKey(x => x.ShoppingCartId).OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey(x => x.ShoppingCartId).OnDelete(DeleteBehavior.ClientCascade);
             modelBuilder.Entity<AddressEntity>().HasOne(x => x.Shipment).WithMany(x => x.Addresses)
-                        .HasForeignKey(x => x.ShipmentId).OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey(x => x.ShipmentId).OnDelete(DeleteBehavior.ClientCascade);
             modelBuilder.Entity<AddressEntity>().HasOne(x => x.Payment).WithMany(x => x.Addresses)
-                        .HasForeignKey(x => x.PaymentId).OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey(x => x.PaymentId).OnDelete(DeleteBehavior.ClientCascade);
 
             modelBuilder.Entity<AddressEntity>().ToTable("CartAddress");
             #endregion
@@ -83,26 +83,26 @@ namespace VirtoCommerce.CartModule.Data.Repositories
             modelBuilder.Entity<TaxDetailEntity>().ToTable("CartTaxDetail").HasKey(x => x.Id);
             modelBuilder.Entity<TaxDetailEntity>().Property(x => x.Id).HasMaxLength(128).ValueGeneratedOnAdd();
             modelBuilder.Entity<TaxDetailEntity>().HasOne(x => x.ShoppingCart).WithMany(x => x.TaxDetails)
-                        .HasForeignKey(x => x.ShoppingCartId).OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey(x => x.ShoppingCartId).OnDelete(DeleteBehavior.ClientCascade);
             modelBuilder.Entity<TaxDetailEntity>().HasOne(x => x.Shipment).WithMany(x => x.TaxDetails)
-                        .HasForeignKey(x => x.ShipmentId).OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey(x => x.ShipmentId).OnDelete(DeleteBehavior.ClientCascade);
             modelBuilder.Entity<TaxDetailEntity>().HasOne(x => x.LineItem).WithMany(x => x.TaxDetails)
-                        .HasForeignKey(x => x.LineItemId).OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey(x => x.LineItemId).OnDelete(DeleteBehavior.ClientCascade);
             modelBuilder.Entity<TaxDetailEntity>().HasOne(x => x.Payment).WithMany(x => x.TaxDetails)
-                        .HasForeignKey(x => x.PaymentId).OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey(x => x.PaymentId).OnDelete(DeleteBehavior.ClientCascade);
             #endregion
 
             #region Discount
             modelBuilder.Entity<DiscountEntity>().ToTable("CartDiscount").HasKey(x => x.Id);
             modelBuilder.Entity<DiscountEntity>().Property(x => x.Id).HasMaxLength(128).ValueGeneratedOnAdd();
             modelBuilder.Entity<DiscountEntity>().HasOne(x => x.ShoppingCart).WithMany(x => x.Discounts)
-                        .HasForeignKey(x => x.ShoppingCartId).OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey(x => x.ShoppingCartId).OnDelete(DeleteBehavior.ClientCascade);
             modelBuilder.Entity<DiscountEntity>().HasOne(x => x.Shipment).WithMany(x => x.Discounts)
-                        .HasForeignKey(x => x.ShipmentId).OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey(x => x.ShipmentId).OnDelete(DeleteBehavior.ClientCascade);
             modelBuilder.Entity<DiscountEntity>().HasOne(x => x.LineItem).WithMany(x => x.Discounts)
-                        .HasForeignKey(x => x.LineItemId).OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey(x => x.LineItemId).OnDelete(DeleteBehavior.ClientCascade);
             modelBuilder.Entity<DiscountEntity>().HasOne(x => x.Payment).WithMany(x => x.Discounts)
-                        .HasForeignKey(x => x.PaymentId).OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey(x => x.PaymentId).OnDelete(DeleteBehavior.ClientCascade);
             #endregion
 
             #region Coupons
@@ -125,22 +125,22 @@ namespace VirtoCommerce.CartModule.Data.Repositories
             //need to set DeleteBehavior.Cascade manually
             modelBuilder.Entity<CartDynamicPropertyObjectValueEntity>().HasOne(p => p.ShoppingCart)
                 .WithMany(s => s.DynamicPropertyObjectValues).HasForeignKey(k => k.ShoppingCartId)
-                .OnDelete(DeleteBehavior.Cascade);
+                .OnDelete(DeleteBehavior.ClientCascade);
 
             //need to set DeleteBehavior.Cascade manually
             modelBuilder.Entity<CartDynamicPropertyObjectValueEntity>().HasOne(p => p.Shipment)
                 .WithMany(s => s.DynamicPropertyObjectValues).HasForeignKey(k => k.ShipmentId)
-                .OnDelete(DeleteBehavior.Cascade);
+                .OnDelete(DeleteBehavior.ClientCascade);
 
             //need to set DeleteBehavior.Cascade manually
             modelBuilder.Entity<CartDynamicPropertyObjectValueEntity>().HasOne(p => p.Payment)
                 .WithMany(s => s.DynamicPropertyObjectValues).HasForeignKey(k => k.PaymentId)
-                .OnDelete(DeleteBehavior.Cascade);
+                .OnDelete(DeleteBehavior.ClientCascade);
 
             //need to set DeleteBehavior.Cascade manually
             modelBuilder.Entity<CartDynamicPropertyObjectValueEntity>().HasOne(p => p.LineItem)
                 .WithMany(s => s.DynamicPropertyObjectValues).HasForeignKey(k => k.LineItemId)
-                .OnDelete(DeleteBehavior.Cascade);
+                .OnDelete(DeleteBehavior.ClientCascade);
 
             modelBuilder.Entity<CartDynamicPropertyObjectValueEntity>().HasIndex(x => new { x.ObjectType, x.ShoppingCartId })
                 .IsUnique(false)

--- a/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartService.cs
+++ b/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartService.cs
@@ -75,7 +75,7 @@ namespace VirtoCommerce.CartModule.Data.Services
 
         public Task DeleteAsync(string[] cartIds, bool softDelete = false)
         {
-            return DeleteAsync((IEnumerable<string>)cartIds);
+            return DeleteAsync((IEnumerable<string>)cartIds, softDelete);
         }
         #endregion
     }


### PR DESCRIPTION
## Description
Unable to delete a cart that has shipment.items
Fail with 
The DELETE statement conflicted with the REFERENCE constraint "FK_CartShipmentItem_CartLineItem_LineItemId". The conflict occurred in database "VirtoCommerce3", table "dbo.CartShipmentItem", column 'LineItemId'.
## References
### QA-test: PT-3867
### Jira-link: https://virtocommerce.atlassian.net/browse/PT-3865
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Cart_3.20.0-pr-90.zip
