### PR TITLE
DL-60: Remove pricing dependency

### DIFF
--- a/src/VirtoCommerce.CartModule.Core/Model/LineItem.cs
+++ b/src/VirtoCommerce.CartModule.Core/Model/LineItem.cs
@@ -6,7 +6,6 @@ using VirtoCommerce.CoreModule.Core.Tax;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.DynamicProperties;
 using VirtoCommerce.Platform.Core.Swagger;
-using VirtoCommerce.PricingModule.Core.Model;
 
 namespace VirtoCommerce.CartModule.Core.Model
 {
@@ -69,8 +68,6 @@ namespace VirtoCommerce.CartModule.Core.Model
         public bool IsReadOnly { get; set; }
 
         public string PriceId { get; set; }
-
-        public Price Price { get; set; }
 
         public virtual decimal ListPrice { get; set; }
 
@@ -152,7 +149,6 @@ namespace VirtoCommerce.CartModule.Core.Model
         {
             var result = MemberwiseClone() as LineItem;
 
-            result.Price = Price?.Clone() as Price;
             result.TaxDetails = TaxDetails?.Select(x => x.Clone()).OfType<TaxDetail>().ToList();
             result.Discounts = Discounts?.Select(x => x.Clone()).OfType<Discount>().ToList();
             result.DynamicProperties = DynamicProperties?.Select(x => x.Clone()).OfType<DynamicObjectProperty>().ToList();

--- a/src/VirtoCommerce.CartModule.Core/VirtoCommerce.CartModule.Core.csproj
+++ b/src/VirtoCommerce.CartModule.Core/VirtoCommerce.CartModule.Core.csproj
@@ -16,7 +16,6 @@
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.200.0" />
         <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.200.0" />
-        <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.200.0" />
         <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.200.0" />
         <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.200.0" />
     </ItemGroup>

--- a/src/VirtoCommerce.CartModule.Web/module.manifest
+++ b/src/VirtoCommerce.CartModule.Web/module.manifest
@@ -25,7 +25,6 @@
     <dependency id="VirtoCommerce.Store" version="3.200.0" />
     <dependency id="VirtoCommerce.Payment" version="3.200.0" />
     <dependency id="VirtoCommerce.Shipping" version="3.200.0" />
-    <dependency id="VirtoCommerce.Pricing" version="3.200.0" />
   </dependencies>
   <groups>
     <group>commerce</group>


### PR DESCRIPTION
## Description
This contribution inspired by performing devlab issue DL-60.
Dependency on the pricing module removed because of redundancy. It seems the full Price in Lineitems is obsolete and used nowhere. (At least, I have sought for every module and found none.)

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/DL-60
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Cart_3.201.0-pr-98.zip
