### PR TITLE
fix syntax error in Mysql in remove cart query

### DIFF
--- a/src/VirtoCommerce.CartModule.Data/Repositories/CartRepository.cs
+++ b/src/VirtoCommerce.CartModule.Data/Repositories/CartRepository.cs
@@ -51,7 +51,8 @@ namespace VirtoCommerce.CartModule.Data.Repositories
 
         public virtual Task SoftRemoveCartsAsync(string[] ids)
         {
-            return ExecuteSqlCommandAsync("UPDATE \"Cart\" SET \"IsDeleted\" = 'true' WHERE \"Id\" IN ({0})", ids);
+            // Literal '1' is supported as true value both for SqlServer, PostgreSql and MySql 
+            return ExecuteSqlCommandAsync("UPDATE \"Cart\" SET \"IsDeleted\" = '1' WHERE \"Id\" IN ({0})", ids);
         }
 
         #region Commands


### PR DESCRIPTION
## Description
'true' literal is not supported as true value in MySql. The remove items from cart query results in a syntax error.
'1' can be used as a true value for all supported providers (SqlServer,PostgreSql,MySql).
Updated the query so that it is correct in MySql as well.

## References
### QA-test:
### Jira-link:
### Artifact URL:
