### PR TITLE
VCST-1244:  Totals were not calculated when using the CartResponseGroup.Full response group.

### DIFF
--- a/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartService.cs
+++ b/src/VirtoCommerce.CartModule.Data/Services/ShoppingCartService.cs
@@ -38,7 +38,8 @@ namespace VirtoCommerce.CartModule.Data.Services
         protected override ShoppingCart ProcessModel(string responseGroup, ShoppingCartEntity entity, ShoppingCart model)
         {
             //Calculate totals only for full responseGroup
-            if (responseGroup == null)
+            if (string.IsNullOrEmpty(responseGroup) ||
+                Enum.Parse<CartResponseGroup>(responseGroup) == CartResponseGroup.Full)
             {
                 _totalsCalculator.CalculateTotals(model);
             }


### PR DESCRIPTION
## Description
fix:  Totals were not calculated when using the CartResponseGroup.Full response group.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1244
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Cart_3.809.0-pr-148-414f.zip