### PR TITLE
VCST-1382: fix no query splitting behavior warning

### DIFF
--- a/src/VirtoCommerce.CartModule.Data/Repositories/CartRepository.cs
+++ b/src/VirtoCommerce.CartModule.Data/Repositories/CartRepository.cs
@@ -99,6 +99,7 @@ namespace VirtoCommerce.CartModule.Data.Repositories
                 var payments = await Payments
                     .Include(x => x.Addresses)
                     .Where(x => ids.Contains(x.ShoppingCartId))
+                    .AsSplitQuery()
                     .ToListAsync();
 
                 if (payments.Any())
@@ -150,6 +151,7 @@ namespace VirtoCommerce.CartModule.Data.Repositories
                 var shipments = await Shipments
                     .Include(x => x.Items)
                     .Where(x => ids.Contains(x.ShoppingCartId))
+                    .AsSplitQuery()
                     .ToListAsync();
 
                 if (shipments.Any())


### PR DESCRIPTION
## Description
fix: Resolves no query splitting behavior warning.  See https://go.microsoft.com/fwlink/?linkid=2134277 for more information. 


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1382
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Cart_3.812.0-pr-151-9a7c.zip