### PR TITLE
VCST-4523: Case Insensitive search for PostgreSQL 18

### DIFF
--- a/src/VirtoCommerce.CartModule.Core/VirtoCommerce.CartModule.Core.csproj
+++ b/src/VirtoCommerce.CartModule.Core/VirtoCommerce.CartModule.Core.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1004.0" />
     <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.1000.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CartModule.Data.MySql/VirtoCommerce.CartModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.CartModule.Data.MySql/VirtoCommerce.CartModule.Data.MySql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1004.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CartModule.Data\VirtoCommerce.CartModule.Data.csproj" />

--- a/src/VirtoCommerce.CartModule.Data.PostgreSql/Migrations/20260224144608_AddCaseInsensitiveCollations.Designer.cs
+++ b/src/VirtoCommerce.CartModule.Data.PostgreSql/Migrations/20260224144608_AddCaseInsensitiveCollations.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VirtoCommerce.CartModule.Data.Repositories;
@@ -11,9 +12,11 @@ using VirtoCommerce.CartModule.Data.Repositories;
 namespace VirtoCommerce.CartModule.Data.PostgreSql.Migrations
 {
     [DbContext(typeof(CartDbContext))]
-    partial class CartDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260224144608_AddCaseInsensitiveCollations")]
+    partial class AddCaseInsensitiveCollations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/VirtoCommerce.CartModule.Data.PostgreSql/Migrations/20260224144608_AddCaseInsensitiveCollations.cs
+++ b/src/VirtoCommerce.CartModule.Data.PostgreSql/Migrations/20260224144608_AddCaseInsensitiveCollations.cs
@@ -1,0 +1,69 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using VirtoCommerce.Platform.Data.PostgreSql.Extensions;
+
+#nullable disable
+
+namespace VirtoCommerce.CartModule.Data.PostgreSql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCaseInsensitiveCollations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateCaseInsensitiveCollationIfNotExists();
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OrganizationName",
+                table: "Cart",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Cart",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "OrganizationName",
+                table: "Cart",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true,
+                oldCollation: "case_insensitive");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Cart",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true,
+                oldCollation: "case_insensitive");
+        }
+    }
+}

--- a/src/VirtoCommerce.CartModule.Data.PostgreSql/ShoppingCartEntityConfiguration.cs
+++ b/src/VirtoCommerce.CartModule.Data.PostgreSql/ShoppingCartEntityConfiguration.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VirtoCommerce.CartModule.Data.Model;
+using VirtoCommerce.Platform.Data.PostgreSql.Extensions;
+
+namespace VirtoCommerce.CartModule.Data.PostgreSql;
+
+public class ShoppingCartEntityConfiguration : IEntityTypeConfiguration<ShoppingCartEntity>
+{
+    public void Configure(EntityTypeBuilder<ShoppingCartEntity> builder)
+    {
+        builder.Property(x => x.Name).UseCaseInsensitiveCollation();
+        builder.Property(x => x.OrganizationName).UseCaseInsensitiveCollation();
+    }
+}

--- a/src/VirtoCommerce.CartModule.Data.PostgreSql/VirtoCommerce.CartModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.CartModule.Data.PostgreSql/VirtoCommerce.CartModule.Data.PostgreSql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1004.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CartModule.Data\VirtoCommerce.CartModule.Data.csproj" />

--- a/src/VirtoCommerce.CartModule.Data.SqlServer/VirtoCommerce.CartModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.CartModule.Data.SqlServer/VirtoCommerce.CartModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1004.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CartModule.Data\VirtoCommerce.CartModule.Data.csproj" />

--- a/src/VirtoCommerce.CartModule.Data/VirtoCommerce.CartModule.Data.csproj
+++ b/src/VirtoCommerce.CartModule.Data/VirtoCommerce.CartModule.Data.csproj
@@ -16,8 +16,8 @@
     
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1004.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1004.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.CartModule.Web/module.manifest
+++ b/src/VirtoCommerce.CartModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1001.0</version>
   <version-tag />
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1004.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
     <dependency id="VirtoCommerce.Core" version="3.1000.0" />


### PR DESCRIPTION
## Description
Case Insensitive search for PostgreSQL 18

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4523
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Cart_3.1001.0-pr-184-ddbc.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Includes a PostgreSQL schema migration that changes column collations, which can impact query behavior and performance during/after deployment. Dependency bumps are straightforward but may introduce platform-level behavior changes.
> 
> **Overview**
> Enables *case-insensitive* behavior for PostgreSQL cart searches by creating a `case_insensitive` collation (if missing) and altering `Cart.Name` and `Cart.OrganizationName` to use it via a new EF Core migration.
> 
> Adds a PostgreSQL-specific `ShoppingCartEntityConfiguration` applying the case-insensitive collation to the EF model, and updates the Postgres model snapshot accordingly.
> 
> Bumps VirtoCommerce Platform package references across Cart projects (Core/Data and DB providers) from `3.1002.0` to `3.1004.0`, and updates `module.manifest` `platformVersion` to `3.1004.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddbc1cf4976defcb3c31a8a2544ea25e5d71dc1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->