### PR TITLE
fix: Return empty list instead of 500 when cart is null

### DIFF
--- a/src/VirtoCommerce.CartModule.Web/Controllers/Api/CartModuleController.cs
+++ b/src/VirtoCommerce.CartModule.Web/Controllers/Api/CartModuleController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -119,6 +120,10 @@ namespace VirtoCommerce.CartModule.Web.Controllers.Api
         public async Task<ActionResult<ICollection<ShippingRate>>> GetAvailableShippingRates(string cartId)
         {
             var cart = await shoppingCartService.GetByIdAsync(cartId, (CartResponseGroup.WithShipments | CartResponseGroup.WithLineItems).ToString());
+            if (cart == null)
+            {
+                return Ok(Array.Empty<ShippingRate>());
+            }
             var builder = cartBuilder.TakeCart(cart);
             var shippingRates = await builder.GetAvailableShippingRatesAsync();
             return Ok(shippingRates);
@@ -128,6 +133,10 @@ namespace VirtoCommerce.CartModule.Web.Controllers.Api
         [Route("availshippingrates")]
         public async Task<ActionResult<ICollection<ShippingRate>>> GetAvailableShippingRatesByContext([FromBody] ShippingEvaluationContext context)
         {
+            if (context?.ShoppingCart == null)
+            {
+                return Ok(Array.Empty<ShippingRate>());
+            }
             var builder = cartBuilder.TakeCart(context.ShoppingCart);
             var shippingRates = await builder.GetAvailableShippingRatesAsync();
             return Ok(shippingRates);
@@ -138,6 +147,10 @@ namespace VirtoCommerce.CartModule.Web.Controllers.Api
         public async Task<ActionResult<ICollection<PaymentMethod>>> GetAvailablePaymentMethods(string cartId)
         {
             var cart = await shoppingCartService.GetByIdAsync(cartId, CartResponseGroup.WithPayments.ToString());
+            if (cart == null)
+            {
+                return Ok(Array.Empty<PaymentMethod>());
+            }
             var paymentMethods = await cartBuilder.TakeCart(cart).GetAvailablePaymentMethodsAsync();
             return Ok(paymentMethods);
         }

--- a/tests/VirtoCommerce.CartModule.Tests/UnitTests/CartModuleControllerTests.cs
+++ b/tests/VirtoCommerce.CartModule.Tests/UnitTests/CartModuleControllerTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using VirtoCommerce.CartModule.Core.Model;
+using VirtoCommerce.CartModule.Core.Services;
+using VirtoCommerce.CartModule.Web.Controllers.Api;
+using VirtoCommerce.PaymentModule.Core.Model;
+using VirtoCommerce.ShippingModule.Core.Model;
+using Xunit;
+
+namespace VirtoCommerce.CartModule.Tests.UnitTests
+{
+    public class CartModuleControllerTests
+    {
+        private readonly Mock<IShoppingCartService> _shoppingCartServiceMock = new();
+        private readonly Mock<IShoppingCartSearchService> _searchServiceMock = new();
+        private readonly Mock<IShoppingCartBuilder> _cartBuilderMock = new();
+        private readonly Mock<IShoppingCartTotalsCalculator> _totalsCalculatorMock = new();
+
+        private CartModuleController CreateSut() => new(
+            _shoppingCartServiceMock.Object,
+            _searchServiceMock.Object,
+            _cartBuilderMock.Object,
+            _totalsCalculatorMock.Object);
+
+        // The controller calls GetByIdAsync, an extension on top of the interface's GetAsync(IList<string>, string, bool).
+        // Moq can only intercept the interface method, so we set up GetAsync.
+        private void SetupCart(string cartId, ShoppingCart cart)
+        {
+            _shoppingCartServiceMock
+                .Setup(x => x.GetAsync(It.Is<IList<string>>(ids => ids.Count == 1 && ids[0] == cartId), It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(cart == null ? new List<ShoppingCart>() : new List<ShoppingCart> { cart });
+        }
+
+        [Fact]
+        public async Task GetAvailableShippingRates_ReturnsEmpty_WhenCartIsNull()
+        {
+            // arrange
+            SetupCart("missing-cart", null);
+
+            // act
+            var result = await CreateSut().GetAvailableShippingRates("missing-cart");
+
+            // assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Empty((ICollection<ShippingRate>)ok.Value);
+            _cartBuilderMock.Verify(x => x.TakeCart(It.IsAny<ShoppingCart>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task GetAvailableShippingRatesByContext_ReturnsEmpty_WhenContextIsNull()
+        {
+            // act
+            var result = await CreateSut().GetAvailableShippingRatesByContext(null);
+
+            // assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Empty((ICollection<ShippingRate>)ok.Value);
+            _cartBuilderMock.Verify(x => x.TakeCart(It.IsAny<ShoppingCart>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task GetAvailablePaymentMethods_ReturnsEmpty_WhenCartIsNull()
+        {
+            // arrange
+            SetupCart("missing-cart", null);
+
+            // act
+            var result = await CreateSut().GetAvailablePaymentMethods("missing-cart");
+
+            // assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Empty((ICollection<PaymentMethod>)ok.Value);
+            _cartBuilderMock.Verify(x => x.TakeCart(It.IsAny<ShoppingCart>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task GetAvailableShippingRates_FlowsThrough_WhenCartIsPresent()
+        {
+            // arrange
+            var cart = new ShoppingCart { Id = "present-cart" };
+            var rates = new[] { new ShippingRate() };
+            SetupCart("present-cart", cart);
+            _cartBuilderMock.Setup(x => x.TakeCart(It.IsAny<ShoppingCart>())).Returns(_cartBuilderMock.Object);
+            _cartBuilderMock.Setup(x => x.GetAvailableShippingRatesAsync()).ReturnsAsync(rates);
+
+            // act
+            var result = await CreateSut().GetAvailableShippingRates("present-cart");
+
+            // assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Same(rates, ok.Value);
+            _cartBuilderMock.Verify(x => x.TakeCart(It.IsAny<ShoppingCart>()), Times.Once);
+        }
+    }
+}

--- a/tests/VirtoCommerce.CartModule.Tests/VirtoCommerce.CartModule.Tests.csproj
+++ b/tests/VirtoCommerce.CartModule.Tests/VirtoCommerce.CartModule.Tests.csproj
@@ -27,5 +27,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.CartModule.Core\VirtoCommerce.CartModule.Core.csproj" />
     <ProjectReference Include="..\..\src\VirtoCommerce.CartModule.Data\VirtoCommerce.CartModule.Data.csproj" />
+    <ProjectReference Include="..\..\src\VirtoCommerce.CartModule.Web\VirtoCommerce.CartModule.Web.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

`CartModuleController.GetAvailableShippingRates`, `…ByContext`, and `GetAvailablePaymentMethods` pass the result of `IShoppingCartService.GetByIdAsync` (or `context.ShoppingCart`) into `ShoppingCartBuilder.TakeCart` without a null check. `TakeCart` throws `ArgumentNullException` on null and the unhandled exception surfaces as HTTP 500 — any time the cart legitimately or transiently doesn't resolve (soft-deleted between client requests, cleaned up by a job, missing in the read replica, or returned as cached-null by the platform's by-id cache before the platform-side fix lands) the endpoint fails. Full analysis in VirtoCommerce/vc-platform#3027.

This change guards each of the three call sites: when the cart can't be resolved, return `Ok(Array.Empty<…>())` instead. Empty rather than 404 because the storefront BFF's downstream `ValidateCartShipmentsAsync` already handles an empty list gracefully (it attaches an `UnavailableError` to each shipment), whereas a 404 would force callers to handle `HttpOperationException`. The guard is also independent of the cache-layer fix, so it protects against future regressions of the same shape.

The companion platform-layer fix is in VirtoCommerce/vc-platform#3029.

### Tests

Added `CartModuleControllerTests` with four tests:

- `GetAvailableShippingRates_ReturnsEmpty_WhenCartIsNull`
- `GetAvailableShippingRatesByContext_ReturnsEmpty_WhenContextIsNull`
- `GetAvailablePaymentMethods_ReturnsEmpty_WhenCartIsNull`
- `GetAvailableShippingRates_FlowsThrough_WhenCartIsPresent` — flow guard for the present-cart path.

## References
### QA-test:
### Jira-link: 
### Artifact URL:
