### PR TITLE
VCST-5163: Stable 15 — Cart (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.CartModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.CartModule.Core/ModuleConstants.cs
@@ -14,8 +14,6 @@ namespace VirtoCommerce.CartModule.Core
             public const string SavedForLater = "SavedForLater";
         }
 
-        [Obsolete("Use CartTypes.Wishlist instead", DiagnosticId = "VC0011", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-        public const string WishlistCartType = CartType.Wishlist;
         public const string DefaultCartName = "default";
 
         public static class Security

--- a/src/VirtoCommerce.CartModule.Core/VirtoCommerce.CartModule.Core.csproj
+++ b/src/VirtoCommerce.CartModule.Core/VirtoCommerce.CartModule.Core.csproj
@@ -14,10 +14,10 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1007.10" />
-    <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1009.0" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1004.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.1005.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CartModule.Data.MySql/VirtoCommerce.CartModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.CartModule.Data.MySql/VirtoCommerce.CartModule.Data.MySql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CartModule.Data\VirtoCommerce.CartModule.Data.csproj" />

--- a/src/VirtoCommerce.CartModule.Data.PostgreSql/VirtoCommerce.CartModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.CartModule.Data.PostgreSql/VirtoCommerce.CartModule.Data.PostgreSql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CartModule.Data\VirtoCommerce.CartModule.Data.csproj" />

--- a/src/VirtoCommerce.CartModule.Data.SqlServer/VirtoCommerce.CartModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.CartModule.Data.SqlServer/VirtoCommerce.CartModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CartModule.Data\VirtoCommerce.CartModule.Data.csproj" />

--- a/src/VirtoCommerce.CartModule.Data/VirtoCommerce.CartModule.Data.csproj
+++ b/src/VirtoCommerce.CartModule.Data/VirtoCommerce.CartModule.Data.csproj
@@ -14,12 +14,12 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1007.10" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1007.10" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1010.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CartModule.Core\VirtoCommerce.CartModule.Core.csproj" />

--- a/src/VirtoCommerce.CartModule.Web/VirtoCommerce.CartModule.Web.csproj
+++ b/src/VirtoCommerce.CartModule.Web/VirtoCommerce.CartModule.Web.csproj
@@ -22,7 +22,7 @@
     <None Remove="node_modules\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.NotificationsModule.TemplateLoader.FileSystem" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.NotificationsModule.TemplateLoader.FileSystem" Version="3.1009.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CartModule.Core\VirtoCommerce.CartModule.Core.csproj" />

--- a/src/VirtoCommerce.CartModule.Web/module.manifest
+++ b/src/VirtoCommerce.CartModule.Web/module.manifest
@@ -4,16 +4,16 @@
   <version>3.1006.0</version>
   <version-tag />
 
-  <platformVersion>3.1007.10</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Notifications" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Search" version="3.1000.0" optional="true" />
-    <dependency id="VirtoCommerce.Shipping" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1010.0" />
+    <dependency id="VirtoCommerce.Notifications" version="3.1009.0" />
+    <dependency id="VirtoCommerce.Payment" version="3.1004.0" />
+    <dependency id="VirtoCommerce.Search" version="3.1004.0" optional="true" />
+    <dependency id="VirtoCommerce.Shipping" version="3.1005.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1005.0" />
   </dependencies>
 
   <title>Shopping Cart</title>

--- a/tests/VirtoCommerce.CartModule.Tests/VirtoCommerce.CartModule.Tests.csproj
+++ b/tests/VirtoCommerce.CartModule.Tests/VirtoCommerce.CartModule.Tests.csproj
@@ -5,7 +5,7 @@
     <noWarn>1591;NU1608</noWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Part of **Stable 15** (Wave 5). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–4 packages on nuget.org. Version handled by CI.

- Removed obsolete WishlistCartType const.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and manifest alignment plus removal of an unused obsolete API constant; no cart business-logic changes in the diff.
> 
> **Overview**
> **Stable 15** alignment for the Cart module: NuGet references and `module.manifest` now target **platform 3.1039.0** and the matching Wave 1–4 module versions (Core, Customer, Notifications, Payment, Shipping, Store, Search, Assets, and platform data providers for MySQL/PostgreSQL/SQL Server).
> 
> The obsolete **`WishlistCartType`** constant is removed from `ModuleConstants`; callers should use **`CartType.Wishlist`** (nothing in this repo still references the old symbol).
> 
> Test tooling bumps **`coverlet.collector`** to 10.0.1 only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f20698144b9a22c9d865669b60206ac550528150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Cart_3.1006.0-pr-191-f206.zip